### PR TITLE
Reverted back to ValueTask to avoid breaking change

### DIFF
--- a/Fluxor.Persist.Sample.Shared/Storage/InMemoryStateStorage.cs
+++ b/Fluxor.Persist.Sample.Shared/Storage/InMemoryStateStorage.cs
@@ -10,19 +10,19 @@ namespace Fluxor.Persist.Sample.Shared.Storage
 
         public void ClearStore() => _store.Clear();
 
-        public Task<object> GetStateAsync(string statename)
+        public ValueTask<object> GetStateAsync(string statename)
         {
             if (_store.ContainsKey(statename))
-                return Task.FromResult(_store[statename]);
+                return ValueTask.FromResult(_store[statename]);
             return default;
         }
 
-        public Task StoreStateAsync(string statename, object state)
+        public ValueTask StoreStateAsync(string statename, object state)
         {
             if (_store.ContainsKey(statename))
                 _store.TryRemove(statename, out _);
             _store.TryAdd(statename, state);
-            return Task.CompletedTask;
+            return ValueTask.CompletedTask;
         }
     }
 }

--- a/Fluxor.Persist.Sample.Shared/Storage/LocalStateStorage.cs
+++ b/Fluxor.Persist.Sample.Shared/Storage/LocalStateStorage.cs
@@ -14,12 +14,12 @@ namespace Fluxor.Persist.Sample.Shared.Storage
             LocalStorage = localStorage;
         }
 
-        public async Task<string> GetStateJsonAsync(string statename)
+        public async ValueTask<string> GetStateJsonAsync(string statename)
         {
             return await LocalStorage.GetItemAsStringAsync(statename);
         }
 
-        public async Task StoreStateJsonAsync(string statename, string json)
+        public async ValueTask StoreStateJsonAsync(string statename, string json)
         {
             await LocalStorage.SetItemAsStringAsync(statename, json);
         }

--- a/Fluxor.Persist/AssemblyInfo.cs
+++ b/Fluxor.Persist/AssemblyInfo.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Text;
 
+#if NETSTANDARD2_0
 namespace System.Runtime.CompilerServices
 {
     public class IsExternalInit { }
 }
+#endif

--- a/Fluxor.Persist/Fluxor.Persist.csproj
+++ b/Fluxor.Persist/Fluxor.Persist.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    
     <Description>Persists fluxor packages</Description>
     <Version>2.0.0</Version>
     <Authors>Greg Pringle</Authors>
@@ -13,6 +13,9 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>    
   </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+	</PropertyGroup>
 	<PropertyGroup>
 		<LangVersion>9.0</LangVersion>
 	</PropertyGroup>
@@ -40,7 +43,10 @@
   <ItemGroup>
     <PackageReference Include="Fluxor" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.2" />
   </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+		<PackageReference Include="System.Text.Json" Version="6.0.2" />
+	</ItemGroup>
 
 </Project>

--- a/Fluxor.Persist/Storage/IObjectStateStorage.cs
+++ b/Fluxor.Persist/Storage/IObjectStateStorage.cs
@@ -4,7 +4,7 @@ namespace Fluxor.Persist.Storage
 {
     public interface IObjectStateStorage
     {
-        public Task<object> GetStateAsync(string statename);
-        public Task StoreStateAsync(string statename, object state);
+        public ValueTask<object> GetStateAsync(string statename);
+        public ValueTask StoreStateAsync(string statename, object state);
     }
 }

--- a/Fluxor.Persist/Storage/IStringStateStorage.cs
+++ b/Fluxor.Persist/Storage/IStringStateStorage.cs
@@ -4,7 +4,7 @@ namespace Fluxor.Persist.Storage
 {
     public interface IStringStateStorage
     {
-        public Task<string> GetStateJsonAsync(string statename);
-        public Task StoreStateJsonAsync(string statename, string json);
+        public ValueTask<string> GetStateJsonAsync(string statename);
+        public ValueTask StoreStateJsonAsync(string statename, string json);
     }
 }


### PR DESCRIPTION

I realized that the previous PR created a breaking change, changing IStringStateStorage and IObjectStorage methods from ValueTask to Task. THis commit reverts it back to ValueTask by adding System.Threading.Task.Extensions on the netstandard2 version.