### PR TITLE
Add Try catch in the SetState method

### DIFF
--- a/Fluxor.Persist/Storage/JsonStoreHandler.cs
+++ b/Fluxor.Persist/Storage/JsonStoreHandler.cs
@@ -44,7 +44,7 @@ namespace Fluxor.Persist.Storage
                 }
                 catch (Exception ex)
                 {
-                    Logger?.LogError("Failed to deserialize state. Skipping. Error:" + ex.ToString());
+                    Logger?.LogError(ex, "Failed to deserialize state. Skipping.");
                 }
             }
             return feature.GetState(); //get initial state
@@ -52,14 +52,20 @@ namespace Fluxor.Persist.Storage
 
         public async Task SetState(IFeature feature)
         {
-            var state = feature.GetState();
-            var options = new JsonSerializerOptions
+            try 
             {
-                WriteIndented = true,
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-            };
-            string serializedState = JsonSerializer.Serialize(state, options);
-            await LocalStorage.StoreStateJsonAsync(feature.GetName(), serializedState);
+                var state = feature.GetState();
+                var options = new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                };
+                string serializedState = JsonSerializer.Serialize(state, options);
+                await LocalStorage.StoreStateJsonAsync(feature.GetName(), serializedState); }
+            catch (Exception e)
+            {
+                Logger?.LogError(e, "Failed to serialize state. Skipping.");
+            }
         }
     }
 }


### PR DESCRIPTION
There are some situations in that exceptions might be raised inside the `SetState` method.

For example, 
```
var str = JsonSerializer.Serialize(new CrashedState{Type = typeof(decimal)});

public class CrashedState
{
    public Type Type { get; set; }
}
```

So, Add Try catch and write some logs are useful here so that we can easily figure out the root cause. Originally, any exceptions raised inside are dismissed due to `feature.StateChanged += Feature_StateChanged;`