### PR TITLE
In JsonStoreHandler, an empty string should be treated similarly to the null string

### DIFF
--- a/Fluxor.Persist/Storage/DictionaryStoreHandler.cs
+++ b/Fluxor.Persist/Storage/DictionaryStoreHandler.cs
@@ -1,32 +1,31 @@
-﻿using Fluxor.Persist.Middleware;
+﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using System.Threading.Tasks;
 
-namespace Fluxor.Persist.Storage
+namespace Fluxor.Persist.Storage;
+
+public sealed class DictionaryStoreHandler : IStoreHandler
 {
-    public class DictionaryStoreHandler : IStoreHandler
+    private readonly IObjectStateStorage _store;
+    private readonly ILogger _logger;
+
+    public DictionaryStoreHandler(IObjectStateStorage store, ILogger<DictionaryStoreHandler> logger)
     {
-        private readonly IObjectStateStorage _store;
-        private ILogger<PersistMiddleware> _logger;
-
-
-        public DictionaryStoreHandler(IObjectStateStorage store, ILogger<PersistMiddleware> logger)
-        {
-            _store = store;
-            _logger = logger;
-        }
-
-        public async Task<object> GetState(IFeature feature)
-        {
-            _logger?.LogDebug($"Rehydrating state {feature.GetName()}");
-            var state = await _store.GetStateAsync(feature.GetName());
-            if (state == null)
-            {
-                _logger?.LogDebug($"No saved state for {feature.GetName()}, skipping");
-                return feature.GetState(); //get initial state
-            }
-            return state;
-        }
-        public async Task SetState(IFeature feature) => await _store.StoreStateAsync(feature.GetName(), feature.GetState());
+        _store = store;
+        _logger = logger;
     }
+
+    public async Task<object> GetState(IFeature feature)
+    {
+        _logger?.LogDebug("Rehydrating state {FeatureName}", feature.GetName());
+        var state = await _store.GetStateAsync(feature.GetName());
+        if (state == null)
+        {
+            _logger?.LogDebug("No saved state for {FeatureName}, skipping", feature.GetName());
+            return feature.GetState(); //get initial state
+        }
+
+        return state;
+    }
+
+    public async Task SetState(IFeature feature) => await _store.StoreStateAsync(feature.GetName(), feature.GetState());
 }

--- a/Fluxor.Persist/Storage/JsonStoreHandler.cs
+++ b/Fluxor.Persist/Storage/JsonStoreHandler.cs
@@ -1,71 +1,72 @@
-﻿using Fluxor.Persist.Middleware;
-using Microsoft.Extensions.Logging;
-using System;
+﻿using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
-namespace Fluxor.Persist.Storage
+namespace Fluxor.Persist.Storage;
+
+public sealed class JsonStoreHandler : IStoreHandler
 {
-    public class JsonStoreHandler : IStoreHandler
+    private readonly IStringStateStorage _localStorage;
+    private readonly ILogger _logger;
+
+    public JsonStoreHandler(IStringStateStorage localStorage, ILogger<JsonStoreHandler> logger)
     {
-        private IStringStateStorage LocalStorage;
-        private ILogger<PersistMiddleware> Logger;
-        public JsonStoreHandler(IStringStateStorage localStorage, ILogger<PersistMiddleware> logger)
+        _localStorage = localStorage;
+        _logger = logger;
+    }
+
+    public async Task<object> GetState(IFeature feature)
+    {
+        _logger?.LogDebug("Rehydrating state {FeatureName}", feature.GetName());
+        string json = await _localStorage.GetStateJsonAsync(feature.GetName());
+        if (string.IsNullOrEmpty(json))
         {
-            LocalStorage = localStorage;
-            Logger = logger;
+            _logger?.LogDebug("No saved state for {FeatureName}, skipping", feature.GetName());
+        }
+        else
+        {
+            ////Logger?.LogDebug($"Deserializing type {feature.GetStateType().ToString()} from json {json}");
+            _logger?.LogDebug("Deserializing type {StateType}", feature.GetStateType());
+            try
+            {
+                object stronglyTypedFeatureState = JsonSerializer.Deserialize(
+                    json,
+                    feature.GetStateType());
+                if (stronglyTypedFeatureState == null)
+                {
+                    _logger?.LogError($"Deserialize returned null");
+                }
+                else
+                    // Now set the feature's state to the deserialized object
+                    return stronglyTypedFeatureState;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Failed to deserialize state. Skipping.");
+            }
         }
 
-        public async Task<object> GetState(IFeature feature)
-        {
-            Logger?.LogDebug($"Rehydrating state {feature.GetName()}");
-            string json = await LocalStorage.GetStateJsonAsync(feature.GetName());
-            if (json == null)
-            {
-                Logger?.LogDebug($"No saved state for {feature.GetName()}, skipping");
-            }
-            else
-            {
-                ////Logger?.LogDebug($"Deserializing type {feature.GetStateType().ToString()} from json {json}");
-                Logger?.LogDebug($"Deserializing type {feature.GetStateType().ToString()}");
-                try
-                {
-                    object stronglyTypedFeatureState = JsonSerializer.Deserialize(
-                        json,
-                        feature.GetStateType());
-                    if (stronglyTypedFeatureState == null)
-                    {
-                        Logger?.LogError($"Deserialize returned null");
-                    }
-                    else
-                        // Now set the feature's state to the deserialized object
-                        return stronglyTypedFeatureState;
-                }
-                catch (Exception ex)
-                {
-                    Logger?.LogError(ex, "Failed to deserialize state. Skipping.");
-                }
-            }
-            return feature.GetState(); //get initial state
-        }
+        return feature.GetState(); //get initial state
+    }
 
-        public async Task SetState(IFeature feature)
+    public async Task SetState(IFeature feature)
+    {
+        try
         {
-            try 
+            var state = feature.GetState();
+            var options = new JsonSerializerOptions
             {
-                var state = feature.GetState();
-                var options = new JsonSerializerOptions
-                {
-                    WriteIndented = true,
-                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-                };
-                string serializedState = JsonSerializer.Serialize(state, options);
-                await LocalStorage.StoreStateJsonAsync(feature.GetName(), serializedState); }
-            catch (Exception e)
-            {
-                Logger?.LogError(e, "Failed to serialize state. Skipping.");
-            }
+                WriteIndented = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
+            string serializedState = JsonSerializer.Serialize(state, options);
+            await _localStorage.StoreStateJsonAsync(feature.GetName(), serializedState);
+        }
+        catch (Exception e)
+        {
+            _logger?.LogError(e, "Failed to serialize state. Skipping.");
         }
     }
 }


### PR DESCRIPTION
In `JsonStoreHandler`, an empty string should be treated similarly to the null string.
- It is possible that we receive an empty JSON string. 
- Of course, the senders should send a null value instead of an empty string. 
- But we don't have a way to indicate that we only accept a null value. That's why we should handle the empty string case.

Improve `ILogger` usage
- The best practice is providing information that we use to make the message via parameters so that the log system can utilize this information later
