### PR TITLE
Update to .NET 9.0 and Fluxor 6.6.0

### DIFF
--- a/Fluxor.Persist.Sample.Server.Json/Fluxor.Persist.Sample.Server.Json.csproj
+++ b/Fluxor.Persist.Sample.Server.Json/Fluxor.Persist.Sample.Server.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fluxor.Persist.Sample.Server.Json/Startup.cs
+++ b/Fluxor.Persist.Sample.Server.Json/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System.Text.Json;
+using Fluxor.Blazor.Web.ReduxDevTools;
 
 namespace Fluxor.Persist.Sample.Server.Json
 {

--- a/Fluxor.Persist.Sample.Server.State/Fluxor.Persist.Sample.Server.State.csproj
+++ b/Fluxor.Persist.Sample.Server.State/Fluxor.Persist.Sample.Server.State.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fluxor.Persist.Sample.Server.State/Startup.cs
+++ b/Fluxor.Persist.Sample.Server.State/Startup.cs
@@ -1,5 +1,6 @@
 using Blazored.LocalStorage;
 using Fluxor;
+using Fluxor.Blazor.Web.ReduxDevTools;
 using Fluxor.Persist.Middleware;
 using Fluxor.Persist.Sample.Shared.Storage;
 using Fluxor.Persist.Sample.Shared.Store.CounterUseCase;

--- a/Fluxor.Persist.Sample.Shared/Fluxor.Persist.Sample.Shared.csproj
+++ b/Fluxor.Persist.Sample.Shared/Fluxor.Persist.Sample.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,14 +9,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazored.LocalStorage" Version="4.3.0" />
-    <PackageReference Include="Fluxor.Blazor.Web" Version="5.9.0" />
-    <PackageReference Include="Fluxor.Blazor.Web.ReduxDevTools" Version="5.9.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.7" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="7.0.7" />
-    <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
+    <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
+    <PackageReference Include="Fluxor.Blazor.Web" Version="6.6.0" />
+    <PackageReference Include="Fluxor.Blazor.Web.ReduxDevTools" Version="6.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.2" />
+    <PackageReference Include="System.Net.Http.Json" Version="9.0.2" />
   </ItemGroup>
 
 

--- a/Fluxor.Persist.Sample.Wasm/Fluxor.Persist.Sample.Wasm.csproj
+++ b/Fluxor.Persist.Sample.Wasm/Fluxor.Persist.Sample.Wasm.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <UserSecretsId>3349caaa-9cb6-434e-9115-a734a221360a</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.7" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.2" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http.Json" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Fluxor.Persist.Sample.Wasm/Program.cs
+++ b/Fluxor.Persist.Sample.Wasm/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Fluxor.Blazor.Web.ReduxDevTools;
 
 namespace Fluxor.Persist.Sample.Wasm
 {

--- a/Fluxor.Persist/Fluxor.Persist.csproj
+++ b/Fluxor.Persist/Fluxor.Persist.csproj
@@ -14,7 +14,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>    
   </PropertyGroup>
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 	<PropertyGroup>
 		<LangVersion>11.0</LangVersion>
@@ -41,12 +41,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fluxor" Version="5.9.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+    <PackageReference Include="Fluxor" Version="6.6.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
   </ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-		<PackageReference Include="System.Text.Json" Version="7.0.3" />
+		<PackageReference Include="System.Text.Json" Version="9.0.2" />
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
 	  <PackageReference Include="Blazored.LocalStorage">


### PR DESCRIPTION
Have a project that uses Fluxor.Persist and can't update Fluxor past version 5.9.0 currently. So this PR updates all the projects to use .NET 9.0 and the most recent Fluxor version. 

Important Note: Fluxor 6.6.0 does not support netstandard2.0
